### PR TITLE
Only commit changed files

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "outputCapture": "std",
+            "internalConsoleOptions": "openOnSessionStart",
+            "program": "${workspaceFolder}/Distribution/action.js",
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "outFiles": [
+                "${workspaceFolder}/Distribution/**/*.js"
+            ],
+            "cwd": "${workspaceFolder}/../JavaScript.SDK",
+            "env": {
+                "INPUT_VERSION": "6.3.1",
+                "INPUT_ROOT": ".",
+                "GITHUB_WORKSPACE": "."
+            }
+        }
+    ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "declaration": false,
         "declarationMap": false,
         "composite": false,
+        "watch": false,
         "outDir": "./Distribution"
     },
     "include": ["**/*.ts"],


### PR DESCRIPTION
## Summary

Fixes a problem using this action in workflows where the file-tree is modified during build (like with the `update-version-info-action`), but the other changes should not be committed. This update makes sure only the changed files (the `package.json` files) are committed and pushed.

### Fixed

- Only the changed `package.json` files are committed and pushed.
